### PR TITLE
[Floc-3635] Increased timeouts

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -254,14 +254,16 @@ module.exports = function(port, jenkinsServer, secret, triggerJobName, jenkinsUs
                     res.sendStatus(200);
                 })
                 .catch(function(err) {
-                    runtimeLog('Finished with error');
+                    runtimeLog('Finished with error : %j', err);
                     handleError(err);
                     res.sendStatus(500);
+                    res.send(JSON.stringify(err))
                 });
         } catch (e) {
-            console.log('Internal server error: ' + e);
+            console.log('Internal server error: %j', e);
             console.log(e.stack);
             res.sendStatus(500);
+            res.send(JSON.stringify(e))
         }
     });
 

--- a/src/server.js
+++ b/src/server.js
@@ -49,7 +49,7 @@ function poll(fn, interval, limit) {
 
     function timeout(promise, time) {
         return Promise.race([promise, delay(time).then(function () {
-            runtimeLog('Operation timed out : interval : %s limit : %limit', interval, limit)
+            runtimeLog('Operation timed out : interval : %s limit : %s', interval, limit)
             throw new Error('Operation timed out');
         })]);
     }
@@ -216,13 +216,13 @@ module.exports = function(port, jenkinsServer, secret, triggerJobName, jenkinsUs
                                 .then(function(body) {
                                     var setupJobStatus = JSON.parse(body);
                                     if (setupJobStatus.result === 'SUCCESS') {
-                                        runtimeLog('Setup job succeded');
+                                        runtimeLog('Setupjob : Succeded');
                                         return true;
                                     } else if (setupJobStatus.result === 'FAILURE') {
-                                        runtimeLog('Setup job failed');
+                                        runtimeLog('Setupjob : Failed');
                                         throw new Error('Build Failed');
                                     }
-                                    runtimeLog('Setup job unexpected outcome : %j', setupJobStatus)
+                                    runtimeLog('Setupjob : Unknown : %s', setupJobStatus.result)
                                     return false;
                                 });
                         };

--- a/src/server.js
+++ b/src/server.js
@@ -50,6 +50,7 @@ function poll(fn, interval, limit) {
     function timeout(promise, time) {
         return Promise.race([promise, delay(time).then(function () {
             runtimeLog('Operation timed out : interval : %s limit : %s', interval, limit)
+            // this never gets caught???
             throw new Error('Operation timed out');
         })]);
     }
@@ -227,7 +228,7 @@ module.exports = function(port, jenkinsServer, secret, triggerJobName, jenkinsUs
                                 });
                         };
 
-                        return poll(checkIfSetupSucceeded, 500, 50000);
+                        return poll(checkIfSetupSucceeded, 500, 2 * 60 * 1000);
                     });
             };
 

--- a/src/server.js
+++ b/src/server.js
@@ -186,7 +186,7 @@ module.exports = function(port, jenkinsServer, secret, triggerJobName, jenkinsUs
                                 });
                         };
 
-                        return poll(checkBuildHasBeenQueued, 500, 20000)
+                        return poll(checkBuildHasBeenQueued, 500, 2 * 60 * 1000)
                             .then(function() {
                                 return buildUrl;
                             });
@@ -252,19 +252,20 @@ module.exports = function(port, jenkinsServer, secret, triggerJobName, jenkinsUs
                 .then(makeBuildRequest)
                 .then(function() {
                     runtimeLog('Finished successfully');
-                    res.sendStatus(200);
+                    res.status(200).end();
                 })
                 .catch(function(err) {
                     runtimeLog('Finished with error : %j', err);
                     handleError(err);
-                    res.sendStatus(500);
-                    res.send(JSON.stringify(err))
+                      
+                    res.status(500).send(JSON.stringify(err)).end();
                 });
         } catch (e) {
             console.log('Internal server error: %j', e);
             console.log(e.stack);
-            res.sendStatus(500);
-            res.send(JSON.stringify(e))
+            
+            res.status(500).send(e.toString()).end();
+            
         }
     });
 


### PR DESCRIPTION
Set the timeouts to 2 minutes for each of the calls to Jenkins

http://ci-live.clusterhq.com:8080/job/setup_ClusterHQ-flocker/buildTimeTrend shows the time these calls are taking. 

2 minutes should allow for 99.96% of the calls to complete.

Additionally - tweaked some of the logging verbosity, 500 now return the stringified error or exception in the body.

https://clusterhq.atlassian.net/browse/FLOC-3635
